### PR TITLE
Simplify capital cities labels

### DIFF
--- a/components/src/maplibre/MapStyle/SWRDataLabLight.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabLight.stories.svelte
@@ -16,7 +16,7 @@
 	});
 
 	const locations = {
-		germany: { lng: 10.962488768573053, lat: 50.958636214954396, zoom: 6 },
+		germany: { lng: 10.962488768573053, lat: 50.958636214954396, zoom: 5 },
 		stugge: { lng: 9.181, lat: 48.772, zoom: 13.5 },
 		berlin: { lng: 13.399, lat: 52.5159, zoom: 12.1977 },
 		frankfurt: { lng: 8.68834, lat: 50.1082, zoom: 11.7923 },

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -6,6 +6,7 @@ import type { SymbolLayerSpecification } from 'maplibre-gl';
 // state capitals so they're not available in the versatiles data until z6
 
 const majorCities = [
+	'Berlin',
 	'Stuttgart',
 	'München',
 	'Mainz',
@@ -164,24 +165,7 @@ export default function makePlaceLabels() {
 			layout: {
 				'text-size': {
 					stops: [
-						[7, 15],
-						[15, 21]
-					]
-				}
-			},
-			paint: {
-				'text-color': tokens.label_secondary
-			}
-		},
-		{
-			id: 'label-place-capital',
-			filter: ['all', ['==', 'kind', 'capital'], ['>', 'population', 1000000]],
-			minzoom: 5,
-			maxzoom: 12,
-			layout: {
-				'text-size': {
-					stops: [
-						[7, 15],
+						[7, 13],
 						[15, 21]
 					]
 				}


### PR DESCRIPTION
- Drops `label-place-capital` layer, adds Berlin to `label-place-major-city` 
- Reduces layer count from 229 to 228.