### PR TITLE
Set package to public on npmjs.org

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -6,7 +6,7 @@
 	"license": "UNLICENSED",
 	"type": "module",
 	"publishConfig": {
-		"access": "restricted"
+		"access": "public"
 	},
 	"repository": {
 		"url": "https://github.com/SWRdata/components"


### PR DESCRIPTION
With each publish, we keep overriding public access on the npm, because access is restricted via `publishConfig` in the `package.json`. 

This PR fixes the issue by setting `access` to `public`.