### PR TITLE
feat(SWRDataLabLight,SWRDataLabDark): Configurable road label density

### DIFF
--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -333,7 +333,7 @@
 				<Map
 					showDebug
 					maxZoom={20}
-					style={SWRDataLabLight({ roads: { labels: 'dense' } })}
+					style={SWRDataLabDark({ roads: { labels: 'dense' } })}
 					initialLocation={{
 						lng: 8.272323926448053,
 						lat: 49.99821205810713,

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -302,7 +302,7 @@
 		</div>
 	</DesignTokens>
 </Story>
-<Story asChild name="feat/459">
+<Story asChild name="feat/459: road label density">
 	<DesignTokens theme="dark">
 		<div class="grid">
 			<div class="container">
@@ -311,9 +311,9 @@
 					style={SWRDataLabDark()}
 					maxZoom={20}
 					initialLocation={{
-						lng: 9.168427169271467,
-						lat: 47.668888671750324,
-						zoom: 14.798741203087438
+						lng: 9.561655796873652,
+						lat: 47.6999494832024,
+						zoom: 15.426291620556794
 					}}
 				>
 					<AttributionControl position="bottom-left" />

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -72,7 +72,7 @@
 			<div class="container">
 				<Map
 					showDebug
-					style={SWRDataLabDark({ roads: { showLabels: false } })}
+					style={SWRDataLabDark({ roads: { labels: 'none' } })}
 					initialLocation={{ ...locations.berlin, zoom: 15 }}
 				>
 					<AttributionControl position="bottom-left" />

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -290,7 +290,31 @@
 					showDebug
 					style={SWRDataLabDark()}
 					maxZoom={20}
-					initialLocation={{lng: 9.558006092459436, lat: 47.69445218974644, zoom: 15.664592047703644}}
+					initialLocation={{
+						lng: 9.558006092459436,
+						lat: 47.69445218974644,
+						zoom: 15.664592047703644
+					}}
+				>
+					<AttributionControl position="bottom-left" />
+				</Map>
+			</div>
+		</div>
+	</DesignTokens>
+</Story>
+<Story asChild name="feat/459">
+	<DesignTokens theme="dark">
+		<div class="grid">
+			<div class="container">
+				<Map
+					showDebug
+					style={SWRDataLabDark()}
+					maxZoom={20}
+					initialLocation={{
+						lng: 9.168427169271467,
+						lat: 47.668888671750324,
+						zoom: 14.798741203087438
+					}}
 				>
 					<AttributionControl position="bottom-left" />
 				</Map>

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -335,9 +335,9 @@
 					maxZoom={20}
 					style={SWRDataLabDark({ roads: { labels: 'dense' } })}
 					initialLocation={{
-						lng: 8.272323926448053,
-						lat: 49.99821205810713,
-						zoom: 15.94311424606843
+						lng: 9.558469031819868,
+						lat: 47.700057918000056,
+						zoom: 14.74477639533513
 					}}
 				>
 					<AttributionControl position="bottom-left" />

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -6,9 +6,10 @@
 	import AttributionControl from '../AttributionControl/AttributionControl.svelte';
 	import GeocoderControl from '../GeocoderControl/GeocoderControl.svelte';
 
-	import { SWRDataLabDark } from './index';
+	import { SWRDataLabDark, SWRDataLabLight } from './index';
 	import locations from './storyLocations';
 	import NavigationControl from '../NavigationControl/NavigationControl.svelte';
+	import { type RoadLabelDensity } from './types';
 
 	const { Story } = defineMeta({
 		title: 'Maplibre/Style/SWR Data Lab Dark',
@@ -302,18 +303,41 @@
 		</div>
 	</DesignTokens>
 </Story>
-<Story asChild name="feat/459: road label density">
+<Story asChild name="feat/459: overview">
 	<DesignTokens theme="dark">
-		<div class="grid">
+		<div class="row">
+			{#each ['none', 'default', 'dense'] as s}
+				<div class="container">
+					{s}
+					<Map
+						showDebug={s === 'dense'}
+						maxZoom={20}
+						style={SWRDataLabDark({ roads: { labels: s as RoadLabelDensity } })}
+						initialLocation={{
+							lng: 8.269931078413038,
+							lat: 50.00421185075504,
+							zoom: 15.210111923487453
+						}}
+					>
+						<AttributionControl position="bottom-left" />
+					</Map>
+				</div>
+			{/each}
+		</div>
+	</DesignTokens>
+</Story>
+<Story asChild name="feat/459: dense">
+	<DesignTokens theme="dark">
+		<div class="row">
 			<div class="container">
 				<Map
 					showDebug
-					style={SWRDataLabDark()}
 					maxZoom={20}
+					style={SWRDataLabLight({ roads: { labels: 'dense' } })}
 					initialLocation={{
-						lng: 9.561655796873652,
-						lat: 47.6999494832024,
-						zoom: 15.426291620556794
+						lng: 8.272323926448053,
+						lat: 49.99821205810713,
+						zoom: 15.94311424606843
 					}}
 				>
 					<AttributionControl position="bottom-left" />
@@ -330,7 +354,12 @@
 		grid-template-rows: auto;
 		height: 700px;
 	}
+	.row {
+		display: flex;
+		height: 700px;
+	}
 	.container {
+		flex-grow: 1;
 		overflow: hidden;
 	}
 </style>

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.ts
@@ -42,7 +42,7 @@ const tokens: styleTokens = {
 	street_tertiary_case: 'hsl(0, 0%, 14%)',
 	label_primary: 'hsl(240, 5%, 96%)',
 	label_secondary: 'hsl(0, 2%, 85%)',
-	label_tertiary: 'hsl(0, 1%, 75%)',
+	label_tertiary: 'hsl(0, 1%, 60%)',
 	boundary_country: '#6e6f71',
 	boundary_country_case: '#181818',
 	boundary_state: 'hsl(218, 4%, 37%)',
@@ -59,7 +59,6 @@ const { walkingLabels, walkingTunnels, walkingSurface, walkingBridges } = makeWa
 const { roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
 const { buildingFootprints, buildingExtrusions, structureExtrusions } = makeBuildings(tokens);
 const { hillshade } = makeHillshade(tokens);
-const { roadLabels } = makeRoadLabels(tokens);
 
 interface styleFunction {
 	(options?: StyleOptions): StyleSpecification;
@@ -72,6 +71,7 @@ const style: styleFunction = (opts) => {
 	} as StyleOptions;
 
 	const { admin } = makeAdmin(tokens, options?.admin);
+	const { roadLabels } = makeRoadLabels(tokens, options?.roads?.labels);
 
 	return {
 		version: 8,
@@ -160,7 +160,7 @@ const style: styleFunction = (opts) => {
 
 			// 8. Labels
 			...(options.roads?.showLabels ? walkingLabels : []),
-			...(options.roads?.showLabels ? roadLabels : []),
+			...roadLabels,
 
 			// 9. Building extrusions
 			...(options.enableBuildingExtrusions ? [buildingExtrusions] : []),

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.ts
@@ -7,12 +7,15 @@ import makeAdmin from './components/Admin';
 import makeBuildings from './components/Buildings';
 import makeLanduse from './components/Landuse';
 import makeTransit from './components/Transit';
-import makePlaceLabels from './components/PlaceLabels';
 import makeWalking from './components/Walking';
 import makeRoads from './components/Roads';
+import makePlaceLabels from './components/PlaceLabels';
+import makeRoadLabels from './components/RoadLabels';
 import makeHillshade from './components/Hillshade';
 
-const tokens = {
+import type { styleTokens } from '../types';
+
+const tokens: styleTokens = {
 	sans_regular: ['swr_sans_regular'],
 	sans_medium: ['swr_sans_medium'],
 	sans_bold: ['swr_sans_bold'],
@@ -53,9 +56,10 @@ const { landuse } = makeLanduse(tokens);
 const { placeLabels, boundaryLabels } = makePlaceLabels(tokens);
 const { airports, transitBridges, transitSurface, transitTunnels } = makeTransit(tokens);
 const { walkingLabels, walkingTunnels, walkingSurface, walkingBridges } = makeWalking(tokens);
-const { roadLabels, roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
+const { roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
 const { buildingFootprints, buildingExtrusions, structureExtrusions } = makeBuildings(tokens);
 const { hillshade } = makeHillshade(tokens);
+const { roadLabels } = makeRoadLabels(tokens);
 
 interface styleFunction {
 	(options?: StyleOptions): StyleSpecification;

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.ts
@@ -38,7 +38,7 @@ const tokens: styleTokens = {
 	street_primary_case: 'hsl(0, 11%, 7%)',
 	street_secondary: 'hsl(220, 3%, 20%)',
 	street_secondary_case: 'hsl(0, 0%, 0%)',
-	street_tertiary: 'hsl(0, 0%, 20%)',
+	street_tertiary: 'hsl(0, 0%, 15%)',
 	street_tertiary_case: 'hsl(0, 0%, 14%)',
 	label_primary: 'hsl(240, 5%, 96%)',
 	label_secondary: 'hsl(0, 2%, 85%)',
@@ -47,7 +47,7 @@ const tokens: styleTokens = {
 	boundary_country_case: '#181818',
 	boundary_state: 'hsl(218, 4%, 37%)',
 	rail: 'hsl(0, 0%, 33%)',
-	building: '#232325',
+	building: '#111',
 	hillshade_light: 'hsla(0, 0%, 77%, 0.15)',
 	hillshade_dark: 'hsla(0, 0%, 0%, 0.65)'
 };

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.ts
@@ -159,7 +159,7 @@ const style: styleFunction = (opts) => {
 			...admin,
 
 			// 8. Labels
-			...(options.roads?.showLabels ? walkingLabels : []),
+			...(options.roads?.labels !== 'none' ? walkingLabels : []),
 			...roadLabels,
 
 			// 9. Building extrusions

--- a/components/src/maplibre/MapStyle/SWRDataLabLight.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabLight.stories.svelte
@@ -279,7 +279,7 @@
 	<DesignTokens theme="light">
 		<div class="grid">
 			<div class="container">
-				<Map showDebug style={SWRDataLabLight({roads: {showLabels: true}})} initialLocation={locations.stugge}>
+				<Map showDebug style={SWRDataLabLight()} initialLocation={locations.stugge}>
 					<AttributionControl position="bottom-left" />
 				</Map>
 			</div>
@@ -290,8 +290,11 @@
 	<DesignTokens theme="light">
 		<div class="grid">
 			<div class="container">
-				<Map showDebug style={SWRDataLabLight({	roads: {
-					showLabels: true}})} initialLocation={{"lng":13.397677524739947,"lat":52.5175142188192,"zoom":14.99}}>
+				<Map
+					showDebug
+					style={SWRDataLabLight()}
+					initialLocation={{ lng: 13.397677524739947, lat: 52.5175142188192, zoom: 14.99 }}
+				>
 					<AttributionControl position="bottom-left" />
 				</Map>
 			</div>
@@ -330,7 +333,7 @@
 			<div class="container">
 				<Map
 					showDebug
-					style={SWRDataLabLight({ enableBuildingExtrusions: true, roads: { showLabels: false } })}
+					style={SWRDataLabLight({ enableBuildingExtrusions: true, roads: { labels: 'none' } })}
 					maxZoom={20}
 					initialLocation={locations.buildings}
 				>

--- a/components/src/maplibre/MapStyle/SWRDataLabLight.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabLight.ts
@@ -48,8 +48,8 @@ const tokens: styleTokens = {
 	street_tertiary_case: 'hsl(0, 0%, 70%)',
 	label_primary: 'hsl(240, 10%, 2%)',
 	label_secondary: 'hsl(0, 0%, 18%)',
-	label_tertiary: 'hsl(60, 1%, 25%)',
-	building: '#f3f2f1',
+	label_tertiary: 'hsl(60, 1%, 35%)',
+	building: '#eee',
 	rail: '#d3d3d3',
 	boundary_country: '#8b8a89',
 	boundary_state: 'hsl(37, 10%, 75%)',
@@ -63,7 +63,6 @@ const { placeLabels, boundaryLabels } = makePlaceLabels(tokens);
 const { airports, transitBridges, transitSurface, transitTunnels } = makeTransit(tokens);
 const { walkingLabels, walkingTunnels, walkingSurface, walkingBridges } = makeWalking(tokens);
 const { roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
-const { roadLabels } = makeRoadLabels(tokens);
 const { buildingFootprints, buildingExtrusions, structureExtrusions } = makeBuildings(tokens);
 const { hillshade } = makeHillshade(tokens);
 
@@ -78,6 +77,7 @@ const style: styleFunction = (opts) => {
 	} as StyleOptions;
 
 	const { admin } = makeAdmin(tokens, options?.admin);
+	const { roadLabels } = makeRoadLabels(tokens, options?.roads?.labels);
 
 	return {
 		version: 8,
@@ -166,7 +166,7 @@ const style: styleFunction = (opts) => {
 
 			// 8. Labels
 			...(options.roads?.showLabels ? walkingLabels : []),
-			...(options.roads?.showLabels ? roadLabels : []),
+			...roadLabels,
 
 			// 9. Building extrusions
 			...(options.enableBuildingExtrusions ? [buildingExtrusions] : []),

--- a/components/src/maplibre/MapStyle/SWRDataLabLight.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabLight.ts
@@ -165,7 +165,7 @@ const style: styleFunction = (opts) => {
 			...admin,
 
 			// 8. Labels
-			...(options.roads?.showLabels ? walkingLabels : []),
+			...(options.roads?.labels !== 'none' ? walkingLabels : []),
 			...roadLabels,
 
 			// 9. Building extrusions

--- a/components/src/maplibre/MapStyle/SWRDataLabLight.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabLight.ts
@@ -7,9 +7,12 @@ import makeLanduse from './components/Landuse';
 import makeTransit from './components/Transit';
 import makePlaceLabels from './components/PlaceLabels';
 import makeWalking from './components/Walking';
+import makeRoadLabels from './components/RoadLabels';
 import makeRoads from './components/Roads';
 import defaultOptions from './defaultOptions';
 import makeHillshade from './components/Hillshade';
+
+import type { styleTokens } from '../types';
 
 const water = {
 	stops: [
@@ -18,7 +21,7 @@ const water = {
 	]
 };
 
-const tokens = {
+const tokens: styleTokens = {
 	sans_regular: ['swr_sans_regular'],
 	sans_medium: ['swr_sans_medium'],
 	sans_bold: ['swr_sans_bold'],
@@ -59,7 +62,8 @@ const { landuse } = makeLanduse(tokens);
 const { placeLabels, boundaryLabels } = makePlaceLabels(tokens);
 const { airports, transitBridges, transitSurface, transitTunnels } = makeTransit(tokens);
 const { walkingLabels, walkingTunnels, walkingSurface, walkingBridges } = makeWalking(tokens);
-const { roadLabels, roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
+const { roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
+const { roadLabels } = makeRoadLabels(tokens);
 const { buildingFootprints, buildingExtrusions, structureExtrusions } = makeBuildings(tokens);
 const { hillshade } = makeHillshade(tokens);
 

--- a/components/src/maplibre/MapStyle/components/Admin.ts
+++ b/components/src/maplibre/MapStyle/components/Admin.ts
@@ -1,6 +1,6 @@
-import { type Layer } from '../../types';
+import { type Layer, type styleTokens } from '../../types';
 
-export default function makeAdmin(tokens, options): any {
+export default function makeAdmin(tokens: styleTokens, options): any {
 	const admin: Layer[] = [
 		{
 			id: 'boundary-country:case',

--- a/components/src/maplibre/MapStyle/components/Buildings.ts
+++ b/components/src/maplibre/MapStyle/components/Buildings.ts
@@ -8,7 +8,7 @@ export default function makeBuildings(tokens: styleTokens): any {
 		maxzoom: 20,
 		paint: {
 			'fill-extrusion-color': tokens.building,
-			'fill-extrusion-opacity': ['interpolate', ['linear'], ['zoom'], 15.5, 0, 16, 1],
+			'fill-extrusion-opacity': ['interpolate', ['linear'], ['zoom'], 14.5, 0, 15, 1],
 			'fill-extrusion-height': [
 				'interpolate',
 				['linear'],

--- a/components/src/maplibre/MapStyle/components/Buildings.ts
+++ b/components/src/maplibre/MapStyle/components/Buildings.ts
@@ -1,15 +1,23 @@
-import { type Layer } from '../../types';
+import { type Layer, type styleTokens } from '../../types';
 
-export default function makeBuildings(tokens): any {
+export default function makeBuildings(tokens: styleTokens): any {
 	const extrusionLayer = {
 		source: 'basemap-de',
 		type: 'fill-extrusion',
 		minzoom: 14,
-    maxzoom: 20,
+		maxzoom: 20,
 		paint: {
 			'fill-extrusion-color': tokens.building,
 			'fill-extrusion-opacity': ['interpolate', ['linear'], ['zoom'], 15.5, 0, 16, 1],
-			'fill-extrusion-height': ['interpolate', ['linear'], ['zoom'], 15.5, 0, 16, ["to-number", ['get', 'hoehe']]]
+			'fill-extrusion-height': [
+				'interpolate',
+				['linear'],
+				['zoom'],
+				15.5,
+				0,
+				16,
+				['to-number', ['get', 'hoehe']]
+			]
 		}
 	};
 

--- a/components/src/maplibre/MapStyle/components/Hillshade.ts
+++ b/components/src/maplibre/MapStyle/components/Hillshade.ts
@@ -1,6 +1,6 @@
-import { type Layer } from '../../types';
+import { type Layer, type styleTokens } from '../../types';
 
-export default function makeHillshade(tokens): any {
+export default function makeHillshade(tokens: styleTokens): any {
 	const hillshade: Layer[] = [
 		{
 			id: 'hillshade-light',

--- a/components/src/maplibre/MapStyle/components/Landuse.ts
+++ b/components/src/maplibre/MapStyle/components/Landuse.ts
@@ -1,6 +1,6 @@
-import { type Layer } from '../../types';
+import { type Layer, type styleTokens } from '../../types';
 
-export default function makeLanduse(tokens): any {
+export default function makeLanduse(tokens: styleTokens): any {
 	const landuse: Layer[] = [
 		{
 			id: 'background',

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -1,4 +1,5 @@
 import type { SymbolLayerSpecification } from 'maplibre-gl';
+import type { styleTokens } from '../../types';
 
 // Hand-authored list of place labes we want to show at low zoom levels
 // Ideally majorCities  would include Frankfurt and Leipzig, but they're not
@@ -11,7 +12,7 @@ const majorCities = ['Berlin', 'Stuttgart', 'München', 'Frankfurt', 'Hamburg', 
 // values for "city" and anything below.
 // See: https://github.com/versatiles-org/shortbread-tilemaker/blob/69e5d4c586a1d2726b746a24829bfb05d4dbeb91/process.lua#L198-L242
 
-export default function makePlaceLabels(tokens) {
+export default function makePlaceLabels(tokens: styleTokens) {
 	const placeLabels: SymbolLayerSpecification[] = [
 		{
 			id: 'label-place-quarter',
@@ -41,10 +42,12 @@ export default function makePlaceLabels(tokens) {
 			layout: {
 				'text-size': {
 					stops: [
-						[11, 14],
-						[15, 16]
+						[14, 12],
+						[16, 17]
 					]
-				}
+				},
+				'text-letter-spacing': 0.1,
+				'text-transform': 'uppercase'
 			},
 			paint: {
 				'text-color': tokens.label_secondary
@@ -63,7 +66,7 @@ export default function makePlaceLabels(tokens) {
 				'text-size': {
 					stops: [
 						[10, 14],
-						[12, 15]
+						[12, 16]
 					]
 				}
 			}
@@ -79,11 +82,13 @@ export default function makePlaceLabels(tokens) {
 				['!in', 'name', ...majorCities]
 			],
 			minzoom: 8.5,
+			maxzoom: 13,
+
 			layout: {
 				'text-size': {
 					stops: [
 						[8, 14],
-						[12, 16]
+						[12, 18]
 					]
 				}
 			}
@@ -184,11 +189,7 @@ export default function makePlaceLabels(tokens) {
 	const boundaryLabels = [
 		{
 			id: 'label-boundary-country',
-			filter: [
-				'all',
-				['==', 'admin_level', 2],
-				['!in', 'name', 'Jersey', 'Guernsey', 'Insel Man']
-			],
+			filter: ['all', ['==', 'admin_level', 2], ['!in', 'name', 'Jersey', 'Guernsey', 'Insel Man']],
 			minzoom: 4,
 			maxzoom: 8,
 			layout: {

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -17,14 +17,17 @@ export default function makePlaceLabels(tokens: styleTokens) {
 		{
 			id: 'label-place-quarter',
 			filter: ['all', ['in', 'kind', 'neighbourhood']],
-			minzoom: 13,
+			minzoom: 14.5,
 			layout: {
 				'text-size': {
 					stops: [
-						[10, 13],
-						[15, 16]
+						[10, 11],
+						[15, 13]
 					]
-				}
+				},
+				'text-letter-spacing': 0.1,
+				'text-transform': 'uppercase',
+				'text-overlap': 'never'
 			},
 			paint: {
 				'text-color': tokens.label_secondary
@@ -42,7 +45,7 @@ export default function makePlaceLabels(tokens: styleTokens) {
 			layout: {
 				'text-size': {
 					stops: [
-						[14, 12],
+						[14, 14],
 						[16, 17]
 					]
 				},

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -25,7 +25,7 @@ export default function makePlaceLabels(tokens: styleTokens) {
 						[15, 13]
 					]
 				},
-				'text-letter-spacing': 0.1,
+				'text-letter-spacing': 0.05,
 				'text-transform': 'uppercase',
 				'text-overlap': 'never'
 			},
@@ -38,18 +38,18 @@ export default function makePlaceLabels(tokens: styleTokens) {
 			filter: [
 				'all',
 				['in', 'kind', 'suburb', 'village', 'hamlet', 'town'],
-				['>', 'population', 1000],
+				['>=', 'population', 1000],
 				['<', 'population', 15_000]
 			],
 			minzoom: 12,
 			layout: {
 				'text-size': {
 					stops: [
-						[14, 14],
-						[16, 17]
+						[14, 11],
+						[16, 15]
 					]
 				},
-				'text-letter-spacing': 0.1,
+				'text-letter-spacing': 0.05,
 				'text-transform': 'uppercase'
 			},
 			paint: {

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -31,7 +31,7 @@ export default function makePlaceLabels(tokens: styleTokens) {
 				'text-font': tokens.sans_regular
 			},
 			paint: {
-				'text-halo-color': tokens.building,
+				'text-halo-color': tokens.background,
 				'text-color': tokens.label_secondary
 			}
 		},
@@ -49,7 +49,7 @@ export default function makePlaceLabels(tokens: styleTokens) {
 				'text-size': {
 					stops: [
 						[14, 11],
-						[16, 15]
+						[16, 18]
 					]
 				},
 				'text-letter-spacing': 0.1,
@@ -57,7 +57,7 @@ export default function makePlaceLabels(tokens: styleTokens) {
 			},
 			paint: {
 				'text-color': tokens.label_secondary,
-				'text-halo-color': tokens.building
+				'text-halo-color': tokens.background
 			}
 		},
 		{

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -16,7 +16,7 @@ export default function makePlaceLabels(tokens: styleTokens) {
 	const placeLabels: SymbolLayerSpecification[] = [
 		{
 			id: 'label-place-quarter',
-			filter: ['all', ['in', 'kind', 'neighbourhood']],
+			filter: ['all', ['in', 'kind', 'neighbourhood'], ['>=', 'population', 200]],
 			minzoom: 14.5,
 			layout: {
 				'text-size': {

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -25,11 +25,13 @@ export default function makePlaceLabels(tokens: styleTokens) {
 						[15, 13]
 					]
 				},
-				'text-letter-spacing': 0.05,
+				'text-letter-spacing': 0.075,
 				'text-transform': 'uppercase',
-				'text-overlap': 'never'
+				'text-overlap': 'never',
+				'text-font': tokens.sans_regular
 			},
 			paint: {
+				'text-halo-color': tokens.building,
 				'text-color': tokens.label_secondary
 			}
 		},
@@ -43,17 +45,19 @@ export default function makePlaceLabels(tokens: styleTokens) {
 			],
 			minzoom: 12,
 			layout: {
+				'text-font': tokens.sans_regular,
 				'text-size': {
 					stops: [
 						[14, 11],
 						[16, 15]
 					]
 				},
-				'text-letter-spacing': 0.05,
+				'text-letter-spacing': 0.1,
 				'text-transform': 'uppercase'
 			},
 			paint: {
-				'text-color': tokens.label_secondary
+				'text-color': tokens.label_secondary,
+				'text-halo-color': tokens.building
 			}
 		},
 		{

--- a/components/src/maplibre/MapStyle/components/RoadLabels.ts
+++ b/components/src/maplibre/MapStyle/components/RoadLabels.ts
@@ -1,0 +1,125 @@
+import type { styleTokens } from '../../types';
+import type { SymbolLayerSpecification } from 'maplibre-gl';
+
+export default function makeRoadLabels(tokens: styleTokens) {
+	const roadLabels: SymbolLayerSpecification[] = [
+		{
+			id: 'label-street-misc',
+			filter: [
+				'in',
+				'kind',
+				'residential',
+				'pedestrian',
+				'path',
+				'track',
+				'steps',
+				'service',
+				'livingstreet',
+				'living_street',
+				'unclassified',
+				'footway'
+			],
+			minzoom: 14,
+			layout: {
+				'text-letter-spacing': 0.05,
+				'text-overlap': 'cooperative',
+				'text-size': {
+					stops: [
+						[12, 10],
+						[15, 11]
+					]
+				}
+			},
+			paint: {
+				'text-color': tokens.label_tertiary
+			}
+		},
+		{
+			id: 'label-street-tertiary',
+			filter: ['==', 'kind', 'tertiary'],
+			minzoom: 14,
+			layout: {
+				'text-overlap': 'cooperative',
+				'text-size': {
+					stops: [
+						[12, 10],
+						[15, 13]
+					]
+				}
+			}
+		},
+		{
+			id: 'label-street-secondary',
+			filter: ['==', 'kind', 'secondary'],
+			minzoom: 14,
+			layout: {
+				'text-letter-spacing': 0.01,
+				'text-size': {
+					stops: [
+						[12, 10],
+						[15, 14]
+					]
+				}
+			},
+			'text-overlap': 'always'
+		},
+		{
+			id: 'label-street-primary',
+			filter: ['==', 'kind', 'primary'],
+			minzoom: 14,
+			layout: {
+				'text-letter-spacing': 0.05,
+				'text-size': {
+					stops: [
+						[12, 10],
+						[15, 13]
+					]
+				},
+				'text-overlap': 'always'
+			},
+			paint: {
+				'text-color': tokens.label_secondary
+			}
+		},
+		{
+			id: 'label-street-trunk',
+			filter: ['==', 'kind', 'trunk'],
+			minzoom: 13,
+			layout: {
+				'text-overlap': 'always',
+				'text-offset': [0, 4],
+				'text-size': {
+					stops: [
+						[12, 10],
+						[15, 13]
+					]
+				}
+			},
+			paint: {
+				'text-color': tokens.label_primary
+			}
+		}
+	].map((el) => {
+		return {
+			type: 'symbol',
+			source: 'versatiles-osm',
+			'source-layer': 'street_labels',
+			...el,
+			layout: {
+				'text-field': '{name}',
+				'text-font': tokens.sans_regular,
+				'symbol-placement': 'line',
+				'text-variable-anchor': ['center', 'left', 'right'],
+				...el.layout
+			},
+			paint: {
+				'text-color': tokens.label_secondary,
+				'text-halo-color': tokens.background,
+				'text-halo-width': 1,
+				...el.paint
+			}
+		};
+	});
+
+	return { roadLabels };
+}

--- a/components/src/maplibre/MapStyle/components/RoadLabels.ts
+++ b/components/src/maplibre/MapStyle/components/RoadLabels.ts
@@ -1,53 +1,60 @@
 import type { styleTokens } from '../../types';
 import type { SymbolLayerSpecification } from 'maplibre-gl';
+import type { RoadLabelDensity } from '../types';
 
-export default function makeRoadLabels(tokens: styleTokens) {
+export default function makeRoadLabels(tokens: styleTokens, density: RoadLabelDensity = 'default') {
+	if (density === 'none') return { roadLabels: [] };
+
 	const roadLabels: SymbolLayerSpecification[] = [
-		{
-			id: 'label-street-misc',
-			filter: [
-				'in',
-				'kind',
-				'residential',
-				'pedestrian',
-				'path',
-				'track',
-				'steps',
-				'service',
-				'livingstreet',
-				'living_street',
-				'unclassified',
-				'footway'
-			],
-			minzoom: 14,
-			layout: {
-				'text-letter-spacing': 0.05,
-				'text-overlap': 'cooperative',
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 11]
-					]
-				}
-			},
-			paint: {
-				'text-color': tokens.label_tertiary
-			}
-		},
-		{
-			id: 'label-street-tertiary',
-			filter: ['==', 'kind', 'tertiary'],
-			minzoom: 14,
-			layout: {
-				'text-overlap': 'cooperative',
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 13]
-					]
-				}
-			}
-		},
+		...(density === 'dense'
+			? [
+					{
+						id: 'label-street-misc',
+						filter: [
+							'in',
+							'kind',
+							'residential',
+							'pedestrian',
+							'path',
+							'track',
+							'steps',
+							'service',
+							'livingstreet',
+							'living_street',
+							'unclassified',
+							'footway'
+						],
+						minzoom: 14,
+						layout: {
+							'text-letter-spacing': 0.05,
+							'text-overlap': 'cooperative',
+							'text-size': {
+								stops: [
+									[12, 10],
+									[15, 11]
+								]
+							}
+						},
+						paint: {
+							'text-color': tokens.label_tertiary
+						}
+					},
+					{
+						id: 'label-street-tertiary',
+						filter: ['==', 'kind', 'tertiary'],
+						minzoom: 14,
+						layout: {
+							'text-overlap': 'cooperative',
+							'text-size': {
+								stops: [
+									[12, 10],
+									[15, 12]
+								]
+							}
+						}
+					}
+				]
+			: []),
 		{
 			id: 'label-street-secondary',
 			filter: ['==', 'kind', 'secondary'],
@@ -56,8 +63,8 @@ export default function makeRoadLabels(tokens: styleTokens) {
 				'text-letter-spacing': 0.01,
 				'text-size': {
 					stops: [
-						[12, 10],
-						[15, 14]
+						[12, 9],
+						[15, 12]
 					]
 				}
 			},
@@ -65,38 +72,17 @@ export default function makeRoadLabels(tokens: styleTokens) {
 		},
 		{
 			id: 'label-street-primary',
-			filter: ['==', 'kind', 'primary'],
+			filter: ['in', 'kind', 'primary', 'trunk'],
 			minzoom: 14,
 			layout: {
-				'text-letter-spacing': 0.05,
+				'text-letter-spacing': 0.03,
 				'text-size': {
 					stops: [
 						[12, 10],
-						[15, 13]
+						[15, 14]
 					]
 				},
 				'text-overlap': 'always'
-			},
-			paint: {
-				'text-color': tokens.label_secondary
-			}
-		},
-		{
-			id: 'label-street-trunk',
-			filter: ['==', 'kind', 'trunk'],
-			minzoom: 13,
-			layout: {
-				'text-overlap': 'always',
-				'text-offset': [0, 4],
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 13]
-					]
-				}
-			},
-			paint: {
-				'text-color': tokens.label_primary
 			}
 		}
 	].map((el) => {
@@ -109,6 +95,7 @@ export default function makeRoadLabels(tokens: styleTokens) {
 				'text-field': '{name}',
 				'text-font': tokens.sans_regular,
 				'symbol-placement': 'line',
+				'text-max-angle': 20,
 				'text-variable-anchor': ['center', 'left', 'right'],
 				...el.layout
 			},

--- a/components/src/maplibre/MapStyle/components/RoadLabels.ts
+++ b/components/src/maplibre/MapStyle/components/RoadLabels.ts
@@ -24,7 +24,7 @@ export default function makeRoadLabels(tokens: styleTokens, density: RoadLabelDe
 							'unclassified',
 							'footway'
 						],
-						minzoom: 14,
+						minzoom: 15,
 						layout: {
 							'text-letter-spacing': 0.05,
 							'text-overlap': 'cooperative',
@@ -42,7 +42,7 @@ export default function makeRoadLabels(tokens: styleTokens, density: RoadLabelDe
 					{
 						id: 'label-street-tertiary',
 						filter: ['==', 'kind', 'tertiary'],
-						minzoom: 14,
+						minzoom: 15,
 						layout: {
 							'text-overlap': 'cooperative',
 							'text-size': {

--- a/components/src/maplibre/MapStyle/components/Roads.ts
+++ b/components/src/maplibre/MapStyle/components/Roads.ts
@@ -195,121 +195,6 @@ export default function makeRoads(tokens: styleTokens) {
 		}
 	};
 
-	const roadLabels: SymbolLayerSpecification[] = [
-		{
-			id: 'label-street-misc',
-			filter: [
-				'in',
-				'kind',
-				'residential',
-				'pedestrian',
-				'livingstreet',
-				'living_street',
-				'unclassified',
-				'footway'
-			],
-			minzoom: 14,
-			layout: {
-				'text-letter-spacing': 0.02,
-				'text-overlap': 'cooperative',
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 12]
-					]
-				}
-			},
-			paint: {
-				'text-color': tokens.label_tertiary
-			}
-		},
-		{
-			id: 'label-street-tertiary',
-			filter: ['==', 'kind', 'tertiary'],
-			minzoom: 14,
-			layout: {
-				'text-overlap': 'cooperative',
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 13]
-					]
-				}
-			}
-		},
-		{
-			id: 'label-street-secondary',
-			filter: ['==', 'kind', 'secondary'],
-			minzoom: 14,
-			layout: {
-				'text-letter-spacing': 0.01,
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 14]
-					]
-				}
-			},
-			'text-overlap': 'always'
-		},
-		{
-			id: 'label-street-primary',
-			filter: ['==', 'kind', 'primary'],
-			minzoom: 14,
-			layout: {
-				'text-letter-spacing': 0.01,
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 14]
-					]
-				},
-				'text-overlap': 'always'
-			},
-			paint: {
-				'text-color': tokens.label_primary
-			}
-		},
-		{
-			id: 'label-street-trunk',
-			filter: ['==', 'kind', 'trunk'],
-			minzoom: 13,
-			layout: {
-				'text-overlap': 'always',
-				'text-offset': [0, 4],
-				'text-size': {
-					stops: [
-						[12, 10],
-						[15, 13]
-					]
-				}
-			},
-			paint: {
-				'text-color': tokens.label_primary
-			}
-		}
-	].map((el) => {
-		return {
-			type: 'symbol',
-			source: 'versatiles-osm',
-			'source-layer': 'street_labels',
-			...el,
-			layout: {
-				'text-field': '{name}',
-				'text-font': tokens.sans_regular,
-				'symbol-placement': 'line',
-				'text-variable-anchor': ['center', 'left', 'right'],
-				...el.layout
-			},
-			paint: {
-				'text-color': tokens.label_secondary,
-				'text-halo-color': tokens.background,
-				'text-halo-width': 1,
-				...el.paint
-			}
-		};
-	});
-
 	const roadBridges: Layer[] = [
 		{
 			id: 'bridge-street-service:case',
@@ -1510,5 +1395,5 @@ export default function makeRoads(tokens: styleTokens) {
 		return { source: 'versatiles-osm', type: 'line', 'source-layer': 'streets', ...el } as Layer;
 	});
 
-	return { roadLabels, roadBridges, roadSurface, roadTunnels };
+	return { roadBridges, roadSurface, roadTunnels };
 }

--- a/components/src/maplibre/MapStyle/components/Roads.ts
+++ b/components/src/maplibre/MapStyle/components/Roads.ts
@@ -971,7 +971,7 @@ export default function makeRoads(tokens: styleTokens) {
 			id: 'street-residential:case',
 			filter: [
 				'all',
-				['==', 'kind', 'residential'],
+				['in', 'kind', 'residential', 'footway'],
 				['!=', 'bridge', true],
 				['!=', 'tunnel', true]
 			],
@@ -1163,10 +1163,10 @@ export default function makeRoads(tokens: styleTokens) {
 		},
 		{
 			id: 'street-footway',
-			filter: ['all', ['in', 'kind', 'footway'], ['!=', 'bridge', true], ['!=', 'tunnel', true]],
+			filter: ['all', ['in', 'kind', 'footway']],
 			paint: {
 				'line-color': street_residential.line_color,
-				'line-width': 2,
+				'line-width': street_residential.line_width,
 				'line-opacity': street_residential.line_opacity
 			},
 			layout: street_layout
@@ -1175,7 +1175,7 @@ export default function makeRoads(tokens: styleTokens) {
 			id: 'street-residential',
 			filter: [
 				'all',
-				['in', 'kind', 'residential', 'livingstreet'],
+				['in', 'kind', 'residential', 'living_street'],
 				['!=', 'bridge', true],
 				['!=', 'tunnel', true]
 			],

--- a/components/src/maplibre/MapStyle/components/Roads.ts
+++ b/components/src/maplibre/MapStyle/components/Roads.ts
@@ -76,7 +76,15 @@ export default function makeRoads(tokens: styleTokens) {
 	const street_primary = {
 		paint: {
 			'line-color': tokens.street_primary,
-			'line-width': motorway.line_width,
+			'line-width': {
+				stops: [
+					[5, 1],
+					[7, 1.5],
+					[11, 2],
+					[12, 3],
+					[14, 6]
+				]
+			},
 			'line-opacity': {
 				stops: [
 					[8, 0],
@@ -90,7 +98,15 @@ export default function makeRoads(tokens: styleTokens) {
 	const street_primary_case = {
 		paint: {
 			'line-color': tokens.street_primary_case,
-			'line-width': motorway_case.line_width,
+			'line-width': {
+				stops: [
+					[5, 1],
+					[7, 1.5],
+					[11, 4],
+					[12, 5],
+					[14, 9]
+				]
+			},
 			'line-opacity': {
 				stops: [
 					[8, 0],
@@ -1136,7 +1152,7 @@ export default function makeRoads(tokens: styleTokens) {
 			id: 'street-service',
 			filter: [
 				'all',
-				['==', 'kind', 'service'],
+				['in', 'kind', 'service', 'footway'],
 				['!=', 'bridge', true],
 				['!=', 'tunnel', true],
 				['!=', 'service', 'driveway']
@@ -1147,7 +1163,7 @@ export default function makeRoads(tokens: styleTokens) {
 					stops: [
 						[14, 1],
 						[16, 3],
-						[18, 16],
+						[18, 12],
 						[19, 44],
 						[20, 88]
 					]
@@ -1161,16 +1177,7 @@ export default function makeRoads(tokens: styleTokens) {
 			},
 			layout: street_layout
 		},
-		{
-			id: 'street-footway',
-			filter: ['all', ['in', 'kind', 'footway']],
-			paint: {
-				'line-color': street_residential.line_color,
-				'line-width': street_residential.line_width,
-				'line-opacity': street_residential.line_opacity
-			},
-			layout: street_layout
-		},
+
 		{
 			id: 'street-residential',
 			filter: [

--- a/components/src/maplibre/MapStyle/components/Roads.ts
+++ b/components/src/maplibre/MapStyle/components/Roads.ts
@@ -1,4 +1,4 @@
-import { type Layer } from '../../types';
+import { type Layer, type styleTokens } from '../../types';
 import type { SymbolLayerSpecification } from 'maplibre-gl';
 
 const street_layout = {
@@ -10,7 +10,7 @@ const case_layout = {
 	'line-cap': 'butt'
 };
 
-export default function makeRoads(tokens) {
+export default function makeRoads(tokens: styleTokens) {
 	const motorway = {
 		line_color: {
 			stops: [
@@ -198,22 +198,37 @@ export default function makeRoads(tokens) {
 	const roadLabels: SymbolLayerSpecification[] = [
 		{
 			id: 'label-street-misc',
-			filter: ['in', 'kind', 'residential', 'livingstreet', 'unclassified'],
-			minzoom: 15,
+			filter: [
+				'in',
+				'kind',
+				'residential',
+				'pedestrian',
+				'livingstreet',
+				'living_street',
+				'unclassified',
+				'footway'
+			],
+			minzoom: 14,
 			layout: {
+				'text-letter-spacing': 0.02,
+				'text-overlap': 'cooperative',
 				'text-size': {
 					stops: [
 						[12, 10],
-						[15, 13]
+						[15, 12]
 					]
 				}
+			},
+			paint: {
+				'text-color': tokens.label_tertiary
 			}
 		},
 		{
 			id: 'label-street-tertiary',
 			filter: ['==', 'kind', 'tertiary'],
-			minzoom: 15,
+			minzoom: 14,
 			layout: {
+				'text-overlap': 'cooperative',
 				'text-size': {
 					stops: [
 						[12, 10],
@@ -227,27 +242,29 @@ export default function makeRoads(tokens) {
 			filter: ['==', 'kind', 'secondary'],
 			minzoom: 14,
 			layout: {
-				'text-letter-spacing': 0.025,
+				'text-letter-spacing': 0.01,
 				'text-size': {
 					stops: [
 						[12, 10],
 						[15, 14]
 					]
 				}
-			}
+			},
+			'text-overlap': 'always'
 		},
 		{
 			id: 'label-street-primary',
 			filter: ['==', 'kind', 'primary'],
 			minzoom: 14,
 			layout: {
-				'text-letter-spacing': 0.025,
+				'text-letter-spacing': 0.01,
 				'text-size': {
 					stops: [
 						[12, 10],
 						[15, 14]
 					]
-				}
+				},
+				'text-overlap': 'always'
 			},
 			paint: {
 				'text-color': tokens.label_primary
@@ -258,6 +275,8 @@ export default function makeRoads(tokens) {
 			filter: ['==', 'kind', 'trunk'],
 			minzoom: 13,
 			layout: {
+				'text-overlap': 'always',
+				'text-offset': [0, 4],
 				'text-size': {
 					stops: [
 						[12, 10],
@@ -279,16 +298,16 @@ export default function makeRoads(tokens) {
 				'text-field': '{name}',
 				'text-font': tokens.sans_regular,
 				'symbol-placement': 'line',
-				'text-anchor': 'center',
+				'text-variable-anchor': ['center', 'left', 'right'],
 				...el.layout
 			},
 			paint: {
 				'text-color': tokens.label_secondary,
 				'text-halo-color': tokens.background,
-				'text-halo-width': 1.5,
+				'text-halo-width': 1,
 				...el.paint
 			}
-		} as SymbolLayerSpecification;
+		};
 	});
 
 	const roadBridges: Layer[] = [
@@ -1258,16 +1277,11 @@ export default function makeRoads(tokens) {
 			layout: street_layout
 		},
 		{
-			id: 'street-livingstreet',
-			filter: [
-				'all',
-				['==', 'kind', 'living_street'],
-				['!=', 'bridge', true],
-				['!=', 'tunnel', true]
-			],
+			id: 'street-footway',
+			filter: ['all', ['in', 'kind', 'footway'], ['!=', 'bridge', true], ['!=', 'tunnel', true]],
 			paint: {
 				'line-color': street_residential.line_color,
-				'line-width': street_residential.line_width,
+				'line-width': 2,
 				'line-opacity': street_residential.line_opacity
 			},
 			layout: street_layout
@@ -1276,7 +1290,7 @@ export default function makeRoads(tokens) {
 			id: 'street-residential',
 			filter: [
 				'all',
-				['==', 'kind', 'residential'],
+				['in', 'kind', 'residential', 'livingstreet'],
 				['!=', 'bridge', true],
 				['!=', 'tunnel', true]
 			],

--- a/components/src/maplibre/MapStyle/components/Transit.ts
+++ b/components/src/maplibre/MapStyle/components/Transit.ts
@@ -1,6 +1,6 @@
-import type { Layer } from '../../types';
+import type { Layer, styleTokens } from '../../types';
 
-export default function makeTransit(tokens) {
+export default function makeTransit(tokens: styleTokens) {
 	const rail = {
 		line_color: tokens.rail,
 		line_dasharray: [2, 2],

--- a/components/src/maplibre/MapStyle/components/Walking.ts
+++ b/components/src/maplibre/MapStyle/components/Walking.ts
@@ -1,4 +1,4 @@
-import { type Layer } from '../../types';
+import { type Layer, type styleTokens } from '../../types';
 import type { SymbolLayerSpecification } from 'maplibre-gl';
 
 const street_layout = {
@@ -6,7 +6,7 @@ const street_layout = {
 	'line-cap': 'butt'
 };
 
-export default function makeWalking(tokens): any {
+export default function makeWalking(tokens: styleTokens): any {
 	const street_residential = {
 		line_color: tokens.street_tertiary,
 		line_width: {

--- a/components/src/maplibre/MapStyle/defaultOptions.ts
+++ b/components/src/maplibre/MapStyle/defaultOptions.ts
@@ -5,9 +5,6 @@ const opts: StyleOptions = {
 	places: {
 		showLabels: true
 	},
-	roads: {
-		showLabels: true
-	},
 	admin: {
 		show: true,
 		showLabels: true

--- a/components/src/maplibre/MapStyle/types.ts
+++ b/components/src/maplibre/MapStyle/types.ts
@@ -2,6 +2,9 @@ enum AdminLevel {
 	COUNTRY = 2,
 	BUNDESLAND = 4
 }
+
+type RoadLabelDensity = 'none' | 'default' | 'dense';
+
 interface StyleOptions {
 	enableBuildingExtrusions?: boolean;
 	enableHillshade?: boolean;
@@ -13,8 +16,8 @@ interface StyleOptions {
 		showLabels?: boolean;
 	};
 	roads?: {
-		showLabels?: boolean;
+		labels?: RoadLabelDensity;
 	};
 }
 
-export type { StyleOptions };
+export type { StyleOptions, RoadLabelDensity };

--- a/components/src/maplibre/types.ts
+++ b/components/src/maplibre/types.ts
@@ -52,3 +52,5 @@ export interface SourceProps {
 	attribution?: string;
 	children?: Snippet;
 }
+
+export type styleTokens = Record<string, string>;

--- a/components/src/maplibre/types.ts
+++ b/components/src/maplibre/types.ts
@@ -53,4 +53,4 @@ export interface SourceProps {
 	children?: Snippet;
 }
 
-export type styleTokens = Record<string, string>;
+export type styleTokens = Record<string, any>;


### PR DESCRIPTION
- Extends `StyleOptions` to take a `roads.labels` argument of type `"none" | "default" | "dense"`, which does what it sounds like.
- Extracts `makeRoadLabels()`
- Changes `livingstreet` to `living_street` to match latest versatiles data
- Tweaks place labels

Closes #459
