### PR TITLE
feat(SWRDataLabLight, SWRDataLabDark): Increase admin label density

### DIFF
--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -357,9 +357,9 @@
 						maxZoom={20}
 						style={SWRDataLabDark({ enableHillshade: true })}
 						initialLocation={{
-							lng: 11.041399193292023,
-							lat: 49.42147382696706,
-							zoom: 11.198697801346833
+							lng: 11.585027613393322,
+							lat: 48.150788140862915,
+							zoom: 11.114287648697289
 						}}
 					>
 						<AttributionControl position="bottom-left" />

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -9,7 +9,6 @@
 	import { SWRDataLabDark, SWRDataLabLight } from './index';
 	import locations from './storyLocations';
 	import NavigationControl from '../NavigationControl/NavigationControl.svelte';
-	import { type LabelDensity } from './types';
 
 	const { Story } = defineMeta({
 		title: 'Maplibre/Style/SWR Data Lab Dark',
@@ -347,20 +346,20 @@
 	</DesignTokens>
 </Story>
 
-<Story asChild name="feat/459: overview">
+<Story asChild name="feat/469: overview">
 	<DesignTokens theme="dark">
 		<div class="row">
-			{#each ['none', 'default', 'dense'] as s}
+			{#each ['default'] as s}
 				<div class="container">
 					{s}
 					<Map
-						showDebug={s === 'dense'}
+						showDebug
 						maxZoom={20}
-						style={SWRDataLabDark({ admin: { labels: s as LabelDensity } })}
+						style={SWRDataLabDark({ enableHillshade: true })}
 						initialLocation={{
-							lng: 8.269931078413038,
-							lat: 50.00421185075504,
-							zoom: 15.210111923487453
+							lng: 11.041399193292023,
+							lat: 49.42147382696706,
+							zoom: 11.198697801346833
 						}}
 					>
 						<AttributionControl position="bottom-left" />

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -9,7 +9,7 @@
 	import { SWRDataLabDark, SWRDataLabLight } from './index';
 	import locations from './storyLocations';
 	import NavigationControl from '../NavigationControl/NavigationControl.svelte';
-	import { type RoadLabelDensity } from './types';
+	import { type LabelDensity } from './types';
 
 	const { Story } = defineMeta({
 		title: 'Maplibre/Style/SWR Data Lab Dark',
@@ -51,7 +51,7 @@
 			<div class="container">
 				<Map
 					showDebug
-					style={SWRDataLabDark({ places: { showLabels: false } })}
+					style={SWRDataLabDark({ places: { labels: 'none' } })}
 					initialLocation={{
 						lng: 8.936,
 						lat: 49.662,
@@ -312,7 +312,7 @@
 					<Map
 						showDebug={s === 'dense'}
 						maxZoom={20}
-						style={SWRDataLabDark({ roads: { labels: s as RoadLabelDensity } })}
+						style={SWRDataLabDark({ roads: { labels: s as LabelDensity } })}
 						initialLocation={{
 							lng: 8.269931078413038,
 							lat: 50.00421185075504,
@@ -346,26 +346,31 @@
 		</div>
 	</DesignTokens>
 </Story>
-<Story asChild name="mid zoom">
+
+<Story asChild name="feat/459: overview">
 	<DesignTokens theme="dark">
 		<div class="row">
-			<div class="container">
-				<Map
-					showDebug
-					maxZoom={20}
-					style={SWRDataLabDark({ roads: { labels: 'dense' } })}
-					initialLocation={{
-						lng: 9.567724147532317,
-						lat: 47.69833827241371,
-						zoom: 9
-					}}
-				>
-					<AttributionControl position="bottom-left" />
-				</Map>
-			</div>
+			{#each ['none', 'default', 'dense'] as s}
+				<div class="container">
+					{s}
+					<Map
+						showDebug={s === 'dense'}
+						maxZoom={20}
+						style={SWRDataLabDark({ admin: { labels: s as LabelDensity } })}
+						initialLocation={{
+							lng: 8.269931078413038,
+							lat: 50.00421185075504,
+							zoom: 15.210111923487453
+						}}
+					>
+						<AttributionControl position="bottom-left" />
+					</Map>
+				</div>
+			{/each}
 		</div>
 	</DesignTokens>
 </Story>
+
 <Story asChild name="State">
 	<DesignTokens theme="dark">
 		<div class="row">

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -357,9 +357,9 @@
 						maxZoom={20}
 						style={SWRDataLabDark({ enableHillshade: true })}
 						initialLocation={{
-							lng: 11.585027613393322,
-							lat: 48.150788140862915,
-							zoom: 11.114287648697289
+							lng: 8.658579253384687,
+							lat: 50.100208477094526,
+							zoom: 10.66488980559805
 						}}
 					>
 						<AttributionControl position="bottom-left" />

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.stories.svelte
@@ -346,6 +346,26 @@
 		</div>
 	</DesignTokens>
 </Story>
+<Story asChild name="mid zoom">
+	<DesignTokens theme="dark">
+		<div class="row">
+			<div class="container">
+				<Map
+					showDebug
+					maxZoom={20}
+					style={SWRDataLabDark({ roads: { labels: 'dense' } })}
+					initialLocation={{
+						lng: 9.567724147532317,
+						lat: 47.69833827241371,
+						zoom: 9
+					}}
+				>
+					<AttributionControl position="bottom-left" />
+				</Map>
+			</div>
+		</div>
+	</DesignTokens>
+</Story>
 <Story asChild name="State">
 	<DesignTokens theme="dark">
 		<div class="row">

--- a/components/src/maplibre/MapStyle/SWRDataLabDark.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabDark.ts
@@ -54,7 +54,7 @@ const tokens: styleTokens = {
 };
 
 const { landuse } = makeLanduse(tokens);
-const { placeLabels, boundaryLabels } = makePlaceLabels(tokens);
+const { placeLabels, boundaryLabels, placeDots } = makePlaceLabels(tokens, {});
 const { airports, transitBridges, transitSurface, transitTunnels } = makeTransit(tokens);
 const { walkingLabels, walkingTunnels, walkingSurface, walkingBridges } = makeWalking(tokens);
 const { roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
@@ -158,6 +158,7 @@ const style: styleFunction = (opts) => {
 
 			// 10. Point labels
 			...(options.places?.showLabels ? placeLabels : []),
+			...(options.places?.showLabels ? placeDots : []),
 
 			// 11. Admin boundary labels
 			...(options.admin?.showLabels ? boundaryLabels : [])

--- a/components/src/maplibre/MapStyle/SWRDataLabLight.stories.svelte
+++ b/components/src/maplibre/MapStyle/SWRDataLabLight.stories.svelte
@@ -50,7 +50,7 @@
 			<div class="container">
 				<Map
 					showDebug
-					style={SWRDataLabLight({ admin: { show: false }, places: { showLabels: false } })}
+					style={SWRDataLabLight({ admin: { show: false }, places: { labels: 'none' } })}
 					initialLocation={{
 						lng: 9.0169,
 						lat: 48.0571,

--- a/components/src/maplibre/MapStyle/SWRDataLabLight.ts
+++ b/components/src/maplibre/MapStyle/SWRDataLabLight.ts
@@ -60,7 +60,7 @@ const tokens: styleTokens = {
 };
 
 const { landuse } = makeLanduse(tokens);
-const { placeLabels, boundaryLabels } = makePlaceLabels(tokens);
+const { placeLabels, boundaryLabels, placeDots } = makePlaceLabels(tokens, {});
 const { airports, transitBridges, transitSurface, transitTunnels } = makeTransit(tokens);
 const { walkingLabels, walkingTunnels, walkingSurface, walkingBridges } = makeWalking(tokens);
 const { roadBridges, roadSurface, roadTunnels } = makeRoads(tokens);
@@ -166,7 +166,7 @@ const style: styleFunction = (opts) => {
 
 			// 10. Point labels
 			...(options.places?.showLabels ? placeLabels : []),
-
+			...(options.places?.showLabels ? placeDots : []),
 			// 11. Admin boundary labels
 			...(options.admin?.showLabels ? boundaryLabels : [])
 		]

--- a/components/src/maplibre/MapStyle/components/Hillshade.ts
+++ b/components/src/maplibre/MapStyle/components/Hillshade.ts
@@ -5,6 +5,7 @@ export default function makeHillshade(tokens: styleTokens): any {
 		{
 			id: 'hillshade',
 			type: 'hillshade',
+			maxzoom: 13,
 			source: 'versatiles-elevation',
 			paint: {
 				'hillshade-exaggeration': 0.05,

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -12,7 +12,7 @@ const majorCities = ['Berlin', 'Stuttgart', 'München', 'Frankfurt', 'Hamburg', 
 // values for "city" and anything below.
 // See: https://github.com/versatiles-org/shortbread-tilemaker/blob/69e5d4c586a1d2726b746a24829bfb05d4dbeb91/process.lua#L198-L242
 
-export default function makePlaceLabels(tokens: styleTokens) {
+export default function makePlaceLabels(tokens: styleTokens, options) {
 	const placeLabels: SymbolLayerSpecification[] = [
 		{
 			id: 'label-place-quarter',

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -95,7 +95,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-size': {
 					stops: [
 						[8, 12],
-						[12, 14]
+						[12, 15]
 					]
 				}
 			},

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -5,7 +5,7 @@ import type { styleTokens } from '../../types';
 // Ideally majorCities  would include Frankfurt and Leipzig, but they're not
 // state capitals so they're not available in the versatiles data until z6
 
-const majorCities = ['Berlin', 'Stuttgart', 'München', 'Frankfurt', 'Hamburg', 'Mainz', 'Nürnberg'];
+const majorCities = ['Berlin', 'Stuttgart', 'München', 'Hamburg', 'Mainz', 'Nürnberg'];
 
 // For smaller cities we use the population field to derive our hierarchy,
 // though that's limited by the fact that versatiles hard-codes population

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -115,7 +115,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 			minzoom: 8,
 			maxzoom: 13,
 			layout: {
-				'text-max-width': 10,
+				'text-max-width': 8,
 				'text-size': {
 					stops: [
 						[8, 12],
@@ -139,9 +139,10 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 			layout: {
 				'text-variable-anchor': ['bottom', 'bottom-left', 'bottom-right', 'right', 'left'],
 				'text-offset': [0.3, 0.4],
+				'text-max-width': 10,
 				'text-size': {
 					stops: [
-						[7, 14],
+						[7, 13],
 						[13, 17]
 					]
 				}
@@ -167,10 +168,10 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 					'right',
 					'left'
 				],
-				'text-offset': [0.2, 0.4],
+				'text-offset': [0.2, 0.35],
 				'text-size': {
 					stops: [
-						[7, 15],
+						[7, 14],
 						[15, 20]
 					]
 				}
@@ -189,11 +190,11 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-offset': [0.4, 0.4],
 				'text-size': {
 					stops: [
-						[7, 15],
+						[7, 16],
 						[15, 28]
 					]
 				},
-				'text-font': tokens.sans_bold
+				'text-font': tokens.sans_medium
 			},
 			paint: {
 				'text-color': tokens.label_secondary
@@ -214,7 +215,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 						[15, 28]
 					]
 				},
-				'text-font': tokens.sans_bold
+				'text-font': tokens.sans_medium
 			},
 			paint: {
 				'text-color': tokens.label_secondary

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -189,7 +189,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-offset': [0.4, 0.4],
 				'text-size': {
 					stops: [
-						[7, 14],
+						[7, 15],
 						[15, 28]
 					]
 				},
@@ -210,7 +210,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-field': 'Frankfurt',
 				'text-size': {
 					stops: [
-						[7, 14],
+						[7, 15],
 						[15, 28]
 					]
 				},
@@ -269,9 +269,9 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 			maxzoom: 12,
 			layout: {},
 			paint: {
-				'circle-radius': 3,
+				'circle-radius': ['interpolate', ['linear'], ['zoom'], 5, 2, 10, 3],
 				'circle-stroke-color': tokens.background,
-				'circle-color': tokens.label_tertiary
+				'circle-color': tokens.label_secondary
 			}
 		}
 	].map((el) => {

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -88,10 +88,11 @@ export default function makePlaceLabels(tokens: styleTokens) {
 				['<', 'population', 50_000],
 				['>', 'population', 15_000]
 			],
-			minzoom: 10,
+			minzoom: 8,
 			layout: {
 				'text-size': {
 					stops: [
+						[8, 10],
 						[10, 14],
 						[12, 16]
 					]

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -54,7 +54,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-max-width': 8
 			},
 			paint: {
-				'text-color': tokens.label_secondary,
+				'text-color': tokens.label_tertiary,
 				'text-halo-color': tokens.background
 			}
 		},
@@ -64,20 +64,21 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'all',
 				['in', 'kind', 'suburb', 'village', 'hamlet', 'town'],
 				['>=', 'population', 2000],
-				['<', 'population', 5_000]
+				['<', 'population', 10_000]
 			],
 			minzoom: 10,
 			layout: {
 				'text-font': tokens.sans_regular,
+				'text-max-width': 8,
 				'text-size': {
 					stops: [
-						[10, 11],
+						[10, 12],
 						[16, 14]
 					]
 				}
 			},
 			paint: {
-				'text-color': tokens.label_secondary
+				'text-color': tokens.label_tertiary
 			}
 		},
 		{
@@ -85,16 +86,16 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 			filter: [
 				'all',
 				['in', 'kind', 'suburb', 'village', 'hamlet', 'town'],
-				['>', 'population', 20_000],
+				['>', 'population', 10_000],
 				['<', 'population', 50_000]
 			],
-			minzoom: 8,
+			minzoom: 9,
 			layout: {
 				'text-max-width': 8,
 				'text-size': {
 					stops: [
-						[8, 11],
-						[12, 16]
+						[8, 12],
+						[12, 14]
 					]
 				}
 			},
@@ -118,7 +119,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-max-width': 8,
 				'text-size': {
 					stops: [
-						[8, 12],
+						[8, 13],
 						[12, 16]
 					]
 				}
@@ -143,7 +144,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-size': {
 					stops: [
 						[7, 13],
-						[13, 17]
+						[13, 18]
 					]
 				}
 			}

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -1,11 +1,11 @@
-import type { SymbolLayerSpecification } from 'maplibre-gl';
+import type { CircleLayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 import type { styleTokens } from '../../types';
 
 // Hand-authored list of place labes we want to show at low zoom levels
 // Ideally majorCities  would include Frankfurt and Leipzig, but they're not
 // state capitals so they're not available in the versatiles data until z6
 
-const majorCities = ['Berlin', 'Stuttgart', 'München', 'Frankfurt', 'Hamburg', 'Mainz'];
+const majorCities = ['Berlin', 'Stuttgart', 'München', 'Frankfurt', 'Hamburg', 'Mainz', 'Nürnberg'];
 
 // For smaller cities we use the population field to derive our hierarchy,
 // though that's limited by the fact that versatiles hard-codes population
@@ -42,7 +42,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				['in', 'kind', 'suburb', 'village', 'hamlet', 'town'],
 				['<', 'population', 2000]
 			],
-			minzoom: 13.5,
+			minzoom: 12,
 			layout: {
 				'text-font': tokens.sans_regular,
 				'text-size': {
@@ -50,7 +50,8 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 						[13, 13],
 						[16, 17]
 					]
-				}
+				},
+				'text-max-width': 8
 			},
 			paint: {
 				'text-color': tokens.label_secondary,
@@ -63,40 +64,42 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'all',
 				['in', 'kind', 'suburb', 'village', 'hamlet', 'town'],
 				['>=', 'population', 2000],
-				['<', 'population', 15_000]
+				['<', 'population', 5_000]
 			],
-			minzoom: 12,
+			minzoom: 10,
 			layout: {
 				'text-font': tokens.sans_regular,
 				'text-size': {
 					stops: [
-						[13, 14],
-						[16, 18]
+						[10, 11],
+						[16, 14]
 					]
 				}
 			},
 			paint: {
-				'text-color': tokens.label_secondary,
-				'text-halo-color': tokens.background
+				'text-color': tokens.label_secondary
 			}
 		},
 		{
 			id: 'label-place-town',
 			filter: [
 				'all',
-				['in', 'kind', 'village', 'hamlet', 'town'],
-				['<', 'population', 50_000],
-				['>', 'population', 15_000]
+				['in', 'kind', 'suburb', 'village', 'hamlet', 'town'],
+				['>', 'population', 20_000],
+				['<', 'population', 50_000]
 			],
 			minzoom: 8,
 			layout: {
+				'text-max-width': 8,
 				'text-size': {
 					stops: [
-						[8, 10],
-						[10, 14],
+						[8, 11],
 						[12, 16]
 					]
 				}
+			},
+			paint: {
+				'text-color': tokens.label_secondary
 			}
 		},
 
@@ -109,14 +112,14 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				['<', 'population', 100_000],
 				['!in', 'name', ...majorCities]
 			],
-			minzoom: 8.5,
+			minzoom: 8,
 			maxzoom: 13,
-
 			layout: {
+				'text-max-width': 10,
 				'text-size': {
 					stops: [
-						[8, 14],
-						[12, 18]
+						[8, 12],
+						[12, 16]
 					]
 				}
 			}
@@ -131,12 +134,14 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				['<', 'population', 400_000],
 				['!in', 'name', ...majorCities]
 			],
-			minzoom: 7.5,
+			minzoom: 7,
 			maxzoom: 13,
 			layout: {
+				'text-variable-anchor': ['bottom', 'bottom-left', 'bottom-right', 'right', 'left'],
+				'text-offset': [0.3, 0.4],
 				'text-size': {
 					stops: [
-						[7, 13],
+						[7, 14],
 						[13, 17]
 					]
 				}
@@ -148,11 +153,21 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'all',
 				['in', 'kind', 'city', 'town', 'state_capital'],
 				['>', 'population', 400_000],
-				['!in', 'name', ...majorCities]
+				['!in', 'name', ...majorCities, 'Frankfurt am Main']
 			],
 			minzoom: 7,
 			maxzoom: 12,
 			layout: {
+				'text-variable-anchor': [
+					'bottom',
+					'bottom-left',
+					'top-right',
+					'top-left',
+					'bottom-right',
+					'right',
+					'left'
+				],
+				'text-offset': [0.2, 0.4],
 				'text-size': {
 					stops: [
 						[7, 15],
@@ -170,12 +185,36 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 			minzoom: 5.5,
 			maxzoom: 12,
 			layout: {
+				'text-variable-anchor': ['bottom', 'bottom-right', 'right', 'left'],
+				'text-offset': [0.4, 0.4],
 				'text-size': {
 					stops: [
 						[7, 14],
-						[15, 25]
+						[15, 28]
 					]
-				}
+				},
+				'text-font': tokens.sans_bold
+			},
+			paint: {
+				'text-color': tokens.label_secondary
+			}
+		},
+		{
+			id: 'label-place-frankfurt',
+			filter: ['==', 'name', 'Frankfurt am Main'],
+			minzoom: 5.5,
+			maxzoom: 12,
+			layout: {
+				'text-variable-anchor': ['bottom', 'bottom-right', 'right', 'left'],
+				'text-offset': [0.4, 0.4],
+				'text-field': 'Frankfurt',
+				'text-size': {
+					stops: [
+						[7, 14],
+						[15, 28]
+					]
+				},
+				'text-font': tokens.sans_bold
 			},
 			paint: {
 				'text-color': tokens.label_secondary
@@ -201,7 +240,47 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-halo-blur': 0.5,
 				...el.paint
 			}
-		} as SymbolLayerSpecification;
+		};
+	});
+
+	const placeDots: CircleLayerSpecification[] = [
+		{
+			id: 'place-dots-minor',
+			minzoom: 7,
+			maxzoom: 13,
+			filter: [
+				'all',
+				['in', 'kind', 'city', 'town'],
+				['>', 'population', 100_000],
+				['<', 'population', 400_000],
+				['!in', 'name', ...majorCities]
+			],
+			layout: {},
+			paint: {
+				'circle-radius': 2,
+				'circle-stroke-color': tokens.background,
+				'circle-color': tokens.label_tertiary
+			}
+		},
+		{
+			id: 'place-dots-major',
+			filter: ['in', 'name', ...majorCities, 'Frankfurt am Main'],
+			minzoom: 5.5,
+			maxzoom: 12,
+			layout: {},
+			paint: {
+				'circle-radius': 3,
+				'circle-stroke-color': tokens.background,
+				'circle-color': tokens.label_tertiary
+			}
+		}
+	].map((el) => {
+		return {
+			type: 'circle',
+			source: 'versatiles-osm',
+			'source-layer': 'place_labels',
+			...el
+		} as CircleLayerSpecification;
 	});
 
 	const boundaryLabels = [
@@ -237,5 +316,5 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 		} as SymbolLayerSpecification;
 	});
 
-	return { placeLabels, boundaryLabels };
+	return { placeLabels, boundaryLabels, placeDots };
 }

--- a/components/src/maplibre/MapStyle/components/PlaceLabels.ts
+++ b/components/src/maplibre/MapStyle/components/PlaceLabels.ts
@@ -192,7 +192,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-size': {
 					stops: [
 						[7, 16],
-						[15, 28]
+						[15, 26]
 					]
 				},
 				'text-font': tokens.sans_medium
@@ -213,7 +213,7 @@ export default function makePlaceLabels(tokens: styleTokens, options) {
 				'text-size': {
 					stops: [
 						[7, 15],
-						[15, 28]
+						[15, 26]
 					]
 				},
 				'text-font': tokens.sans_medium

--- a/components/src/maplibre/MapStyle/components/RoadLabels.ts
+++ b/components/src/maplibre/MapStyle/components/RoadLabels.ts
@@ -1,8 +1,8 @@
 import type { styleTokens } from '../../types';
 import type { SymbolLayerSpecification } from 'maplibre-gl';
-import type { RoadLabelDensity } from '../types';
+import type { LabelDensity } from '../types';
 
-export default function makeRoadLabels(tokens: styleTokens, density: RoadLabelDensity = 'default') {
+export default function makeRoadLabels(tokens: styleTokens, density: LabelDensity = 'default') {
 	if (density === 'none') return { roadLabels: [] };
 
 	const roadLabels: SymbolLayerSpecification[] = [

--- a/components/src/maplibre/MapStyle/components/Roads.ts
+++ b/components/src/maplibre/MapStyle/components/Roads.ts
@@ -200,7 +200,10 @@ export default function makeRoads(tokens: styleTokens) {
 		line_width: {
 			stops: [
 				[14, 0],
-				[15, 4]
+				[16, 4],
+				[18, 26],
+				[19, 62],
+				[20, 122]
 			]
 		},
 		line_opacity: {

--- a/components/src/maplibre/MapStyle/types.ts
+++ b/components/src/maplibre/MapStyle/types.ts
@@ -3,22 +3,23 @@ enum AdminLevel {
 	BUNDESLAND = 4
 }
 
-type RoadLabelDensity = 'none' | 'default' | 'dense';
+type LabelDensity = 'none' | 'default' | 'dense';
+
 type AdminOptions = {
 	show?: boolean | AdminLevel[];
-	showLabels?: boolean;
+	showLabels?: boolean | AdminLevel[];
 };
 
 interface StyleOptions {
 	enableBuildingExtrusions?: boolean;
 	enableHillshade?: boolean;
 	places?: {
-		showLabels?: boolean;
+		labels: LabelDensity;
 	};
 	admin?: AdminOptions;
 	roads?: {
-		labels?: RoadLabelDensity;
+		labels?: LabelDensity;
 	};
 }
 
-export type { StyleOptions, RoadLabelDensity, AdminOptions };
+export type { StyleOptions, LabelDensity, AdminOptions };


### PR DESCRIPTION
After:
<img width="1167" height="688" alt="image" src="https://github.com/user-attachments/assets/a5a3bf33-c226-4233-9cac-e73f7aa578dd" />

- limited by coarse `population` numbers in the versatiles data
- needs a bigger refactor to properly support variable density

Closes #469
