### PR TITLE
chore: Enforce NPM v12 and disallow dependency install scripts 

### DIFF
--- a/.github/workflows/deploy-sophora-components.yml
+++ b/.github/workflows/deploy-sophora-components.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+      - run: npm install -g npm@12
       - name: Create .env file for production
         run: |
           touch .env

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
+      - run: npm install -g npm@12
       - name: Create .env file for production
         run: |
           touch .env

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.15.0
+      - run: npm install -g npm@12
       - run: npm ci --workspace=components --include=dev
       - run: npm run sync --workspace=components
       - run: npm ci --workspace=mock-sveltekit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org/'
           package-manager-cache: false
+      - run: npm install -g npm@12
       - run: npm ci
       - run: npm audit signatures
       - name: Release

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.15.0
+      - run: npm install -g npm@12
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm run sync

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+strict-allow-scripts=true

--- a/components/package.json
+++ b/components/package.json
@@ -5,6 +5,10 @@
 	"author": "SWR Data Lab",
 	"license": "UNLICENSED",
 	"type": "module",
+	"engines": {
+		"node": "24.x",
+		"npm": "12.x"
+	},
 	"keywords": [
 		"svelte"
 	],

--- a/mock-sophora/package.json
+++ b/mock-sophora/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": "24.x",
+    "npm": "12.x"
+  },
   "scripts": {
     "build": "npx @11ty/eleventy",
     "start": "npx @11ty/eleventy --serve --quiet",

--- a/mock-sveltekit/package.json
+++ b/mock-sveltekit/package.json
@@ -3,6 +3,10 @@
 	"version": "0.0.1",
 	"private": true,
 	"type": "module",
+	"engines": {
+		"node": "24.x",
+		"npm": "12.x"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"start": "vite dev",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,16 @@
 		"svelte-select": {
 			"svelte-floating-ui": "1.5.9"
 		}
+	},
+	"allowScripts": {
+		"@swc/core@1.15.41": false,
+		"svelte-preprocess@6.0.3": false,
+		"fsevents@2.3.3": false,
+		"fsevents@2.3.2": false,
+		"@parcel/watcher@2.5.6": false,
+		"esbuild@0.28.1": false,
+		"puppeteer@22.15.0": false,
+		"sharp@0.34.5": false,
+		"unrs-resolver@1.12.2": false
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
 	"scripts": {},
 	"author": "",
 	"license": "UNLICENSED",
+	"engines": {
+		"node": "24.x",
+		"npm": "12.x"
+	},
 	"workspaces": [
 		"components",
 		"sophora-components",

--- a/sophora-components/package.json
+++ b/sophora-components/package.json
@@ -3,6 +3,10 @@
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",
+	"engines": {
+		"node": "24.x",
+		"npm": "12.x"
+	},
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build",


### PR DESCRIPTION
Prepare the project for changes in npm v12, which changes handling of scripts run in the dependency tree – before, during, and after `npm install`, as a precaution against supply chain attacks ([background](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/), [community discussion](https://github.com/orgs/community/discussions/198547))
 
1. Enforce `node@24` (lts) and `npm@12` (current) for all packages, for consistency across dev environments
2. Use `node@24` and `npm@12` in Github actions
3. Explicitly **disallow** all relevant scripts currently present in the dependency tree

I did not notice any problems resulting from scripts not running. But we could also **allow** scripts that are currently present, which would be the same behavior as with previous versions of npm. 

Closes https://github.com/SWRdata/components/issues/482