### PR TITLE
chore: Run semantic-release using NPM v12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: npm run semantic-release


### PR DESCRIPTION
`npm@12` is already installed but it is not picked up in the "Release" workflow task.

This _should_ run `semantic-release` using the correct npm version.  

Unclear why we have been using `npx` to run the release so far. `semantic-release` was already listed in [dev dependencies and scripts](https://github.com/SWRdata/components/blob/84c0e049a6b1640de9a249f0eee89ae10c52b27b/components/package.json#L37).  
 
Closes #496