### PR TITLE
fix: Downgrade npm to v11.16 for compatibility

### DIFF
--- a/.github/workflows/deploy-sophora-components.yml
+++ b/.github/workflows/deploy-sophora-components.yml
@@ -24,8 +24,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
-      - run: npm install -g npm@12
+          node-version: 24.18
       - name: Create .env file for production
         run: |
           touch .env

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -18,8 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
-      - run: npm install -g npm@12
+          node-version: 24.18
       - name: Create .env file for production
         run: |
           touch .env

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,8 +21,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24.15.0
-      - run: npm install -g npm@12
+          node-version: 24.18
       - run: npm ci --workspace=components --include=dev
       - run: npm run sync --workspace=components
       - run: npm ci --workspace=mock-sveltekit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,9 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 24.18
           registry-url: 'https://registry.npmjs.org/'
           package-manager-cache: false
-      - run: npm install -g npm@12
       - run: npm ci
       - run: npm audit signatures
       - name: Release

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -22,8 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24.15.0
-      - run: npm install -g npm@12
+          node-version: 24.18
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm run sync

--- a/components/package.json
+++ b/components/package.json
@@ -6,8 +6,7 @@
 	"license": "UNLICENSED",
 	"type": "module",
 	"engines": {
-		"node": "24.x",
-		"npm": "12.x"
+		"node": "^24.18.0"
 	},
 	"keywords": [
 		"svelte"

--- a/mock-sophora/package.json
+++ b/mock-sophora/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "index.js",
   "engines": {
-    "node": "24.x",
-    "npm": "12.x"
+		"node": "^24.18.0"
   },
   "scripts": {
     "build": "npx @11ty/eleventy",

--- a/mock-sveltekit/package.json
+++ b/mock-sveltekit/package.json
@@ -4,8 +4,7 @@
 	"private": true,
 	"type": "module",
 	"engines": {
-		"node": "24.x",
-		"npm": "12.x"
+		"node": "^24.18.0"
 	},
 	"scripts": {
 		"dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
 	"author": "",
 	"license": "UNLICENSED",
 	"engines": {
-		"node": "24.x",
-		"npm": "12.x"
+		"node": "^24.18.0"
 	},
 	"workspaces": [
 		"components",

--- a/sophora-components/package.json
+++ b/sophora-components/package.json
@@ -4,8 +4,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"engines": {
-		"node": "24.x",
-		"npm": "12.x"
+		"node": "^24.18.0"
 	},
 	"scripts": {
 		"dev": "vite",


### PR DESCRIPTION
Fix problems with release script by downgrading npm from v12 to v11.16.

- Set engine to node v24.18 or greater (comes with npm 11.16.0)
- Lock node to v24.18 for workflows